### PR TITLE
Inherit from custom ApplicationController

### DIFF
--- a/app/controllers/rails_client_checker/application_controller.rb
+++ b/app/controllers/rails_client_checker/application_controller.rb
@@ -1,0 +1,4 @@
+module RailsClientChecker
+  class ApplicationController < ActionController::Base
+  end
+end

--- a/app/controllers/rails_client_checker/checker_controller.rb
+++ b/app/controllers/rails_client_checker/checker_controller.rb
@@ -1,6 +1,8 @@
+require_dependency "rails_client_checker/application_controller"
+
 module RailsClientChecker
 class CheckerController < ApplicationController
-  def check 
+  def check
     render layout: false
   end
 

--- a/lib/rails_client_checker/version.rb
+++ b/lib/rails_client_checker/version.rb
@@ -1,3 +1,3 @@
-module RailsClientChecker 
-  VERSION = "0.0.2"
+module RailsClientChecker
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
This commit refactors `CheckerController` to inherit from its own custom `ApplicationController`, instead of inheriting from the main Rails application.
